### PR TITLE
[PD] Move active body dialog to its own class

### DIFF
--- a/src/Mod/PartDesign/Gui/CMakeLists.txt
+++ b/src/Mod/PartDesign/Gui/CMakeLists.txt
@@ -214,6 +214,8 @@ SET(PartDesignGuiTaskDlgs_SRCS
     TaskHelixParameters.ui
     TaskHelixParameters.h
     TaskHelixParameters.cpp
+    DlgActiveBody.h
+    DlgActiveBody.cpp
 )
 SOURCE_GROUP("TaskDialogs" FILES ${PartDesignGuiTaskDlgs_SRCS})
 

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -70,6 +70,7 @@
 #include "WorkflowManager.h"
 #include "ViewProvider.h"
 #include "ViewProviderBody.h"
+#include "DlgActiveBody.h"
 
 // TODO Remove this header after fixing code so it won;t be needed here (2015-10-20, Fat-Zer)
 #include "ui_DlgReference.h"
@@ -509,7 +510,9 @@ void CmdPartDesignNewSketch::activated(int iMsg)
             if ( doc->countObjectsOfType(PartDesign::Body::getClassTypeId()) == 0 ) {
                 shouldMakeBody = true;
             } else {
-                pcActiveBody = PartDesignGui::needActiveBodyMessage(doc);
+                PartDesignGui::DlgActiveBody dia(Gui::getMainWindow(), doc);
+                if (dia.exec() == QDialog::DialogCode::Accepted)
+                    pcActiveBody = dia.getActiveBody();
                 if (!pcActiveBody)
                     return;
             }

--- a/src/Mod/PartDesign/Gui/CommandPrimitive.cpp
+++ b/src/Mod/PartDesign/Gui/CommandPrimitive.cpp
@@ -41,6 +41,7 @@
 
 #include "Utils.h"
 #include "WorkflowManager.h"
+#include "DlgActiveBody.h"
 
 using namespace std;
 
@@ -89,7 +90,9 @@ void CmdPrimtiveCompAdditive::activated(int iMsg)
         if ( doc->getObjectsOfType(PartDesign::Body::getClassTypeId()).empty() ) {
             shouldMakeBody = true;
         } else {
-            pcActiveBody = PartDesignGui::needActiveBodyMessage(doc);
+            PartDesignGui::DlgActiveBody dia(Gui::getMainWindow(), doc);
+            if (dia.exec() == QDialog::DialogCode::Accepted)
+                pcActiveBody = dia.getActiveBody();
             if (!pcActiveBody)
                 return;
         }

--- a/src/Mod/PartDesign/Gui/DlgActiveBody.cpp
+++ b/src/Mod/PartDesign/Gui/DlgActiveBody.cpp
@@ -1,0 +1,95 @@
+ /**************************************************************************
+ *   Copyright (c) 2021 FreeCAD Developers                                 *
+ *   Author: Ajinkya Dahale                                                *
+ *   Based on src/Gui/DlgAddProperty.cpp                                   *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+#ifndef _PreComp_
+# include <QMessageBox>
+#endif
+
+#include <Gui/Application.h>
+
+#include "DlgActiveBody.h"
+#include "ReferenceSelection.h"
+#include "Utils.h"
+
+Q_DECLARE_METATYPE(App::DocumentObject*);
+
+using namespace PartDesignGui;
+
+DlgActiveBody::DlgActiveBody(QWidget *parent, App::Document*& doc,
+                             const QString& infoText)
+    : QDialog(parent),
+      ui(new Ui_DlgActiveBody),
+      _doc(doc),
+      activeBody(nullptr)
+{
+    ui->setupUi(this);
+
+    QObject::connect(ui->bodySelect, SIGNAL(itemDoubleClicked(QListWidgetItem *)),
+                     this, SLOT(accept()));
+
+    if(!infoText.isEmpty()) {
+        ui->label->setText(infoText + QObject::tr("\n\n") +
+                           QObject::tr("Please select"));
+    }
+
+    auto bodies = _doc->getObjectsOfType(PartDesign::Body::getClassTypeId());
+
+    PartDesign::Body* bodyOfActiveObject = nullptr;
+    for (const auto &obj :  Gui::Selection().getSelection()) {
+        bodyOfActiveObject = PartDesign::Body::findBodyOf(obj.pObject);
+        break; // Just get the body for first selected object
+    }
+
+    for (const auto &body : bodies) {
+        auto item = new QListWidgetItem(QString::fromUtf8(body->Label.getValue()));
+        item->setData(Qt::UserRole, QVariant::fromValue(body));
+        ui->bodySelect->addItem(item);
+
+        if (body == bodyOfActiveObject) {
+            item->setSelected(true);
+        }
+
+        // TODO: Any other logic (hover, select effects on view etc.)
+    }
+}
+
+void DlgActiveBody::accept()
+{
+    auto selectedItems = ui->bodySelect->selectedItems();
+    if (selectedItems.empty())
+        return;
+
+    App::DocumentObject* selectedBody =
+        selectedItems[0]->data(Qt::UserRole).value<App::DocumentObject*>();
+    if (selectedBody)
+        activeBody = makeBodyActive(selectedBody, _doc);
+    else
+        activeBody = makeBody(_doc);
+
+    QDialog::accept();
+}
+
+#include "moc_DlgActiveBody.cpp"

--- a/src/Mod/PartDesign/Gui/DlgActiveBody.h
+++ b/src/Mod/PartDesign/Gui/DlgActiveBody.h
@@ -1,0 +1,59 @@
+ /**************************************************************************
+ *   Copyright (c) 2021 FreeCAD Developers                                 *
+ *   Author: Ajinkya Dahale                                                *
+ *   Based on src/Gui/DlgAddProperty.h                                     *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef PARTDESIGNGUI_DLGACTIVEBODY_H
+#define PARTDESIGNGUI_DLGACTIVEBODY_H
+
+#include <App/Document.h>
+#include <Mod/PartDesign/App/Body.h>
+
+// TODO: Apparently this header can be avoided. See ./Command.cpp:74.
+#include "ui_DlgActiveBody.h"
+
+namespace PartDesignGui {
+
+/** Dialog box to ask user to pick a Part Design body to make active
+ *  or make a new one
+ */
+class PartDesignGuiExport DlgActiveBody : public QDialog
+{
+    Q_OBJECT
+
+public:
+    DlgActiveBody(QWidget* parent, App::Document*& doc,
+                  const QString& infoText=QString());
+
+    void accept() override;
+    PartDesign::Body* getActiveBody() { return activeBody; };
+
+private:
+    std::unique_ptr<Ui_DlgActiveBody> ui;
+    App::Document* _doc;
+    PartDesign::Body* activeBody;
+};
+
+} // namespace PartDesignGui
+
+#endif // PARTDESIGNGUI_DLGACTIVEBODY_H


### PR DESCRIPTION
As suggested by @chennes to keep `Utils.cpp` clean and be more in line with Qt
guidelines.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, we ask you to conform to the following items. Pull requests which don't satisfy all the items below might be rejected. If you are in doubt with any of the items below, don't hesitate to ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10)!

- [x]  Your pull request is confined strictly to a single module. That is, all the files changed by your pull request are either in `App`, `Base`, `Gui` or one of the `Mod` subfolders. If you need to make changes in several locations, make several pull requests and wait for the first one to be merged before submitting the next ones
- [x]  This PR is to augment a bigger PR made to FreeCAD
- [x]  Branch is rebased on `master`.
- [x]  All FreeCAD unit tests are confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x]  All commit messages are [well-written](https://chris.beams.io/posts/git-commit/) ex: `Fixes typo in Draft Move command text`
- [x]  Your pull request is well written and has a good description, and its title starts with the module name, ex: `Draft: Fixed typos`
- [x]  Addresses FC issue#4288

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.20 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=56135).

---
